### PR TITLE
Changed proto structure & Added virtual register name

### DIFF
--- a/gematria/basic_block/basic_block.cc
+++ b/gematria/basic_block/basic_block.cc
@@ -201,7 +201,8 @@ void InstructionOperand::AddTokensToList(
     case OperandType::kMemory:
       tokens.emplace_back(kMemoryToken);
       break;
-    default:
+    case OperandType::kVirtualRegister:
+      tokens.emplace_back(std::string{kVirtualRegisterToken} + std::to_string(size()) + "_");
       break;
   }
 }

--- a/gematria/basic_block/basic_block.cc
+++ b/gematria/basic_block/basic_block.cc
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& os, OperandType operand_type) {
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kFpImmediateValue);
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kAddress);
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kMemory);
-    GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::KVirtualRegister);
+    GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kVirtualRegister);
   }
   return os;
 }
@@ -102,7 +102,7 @@ bool InstructionOperand::operator==(const InstructionOperand& other) const {
       return address() == other.address();
     case OperandType::kMemory:
       return alias_group_id() == other.alias_group_id();
-    case OperandType::KVirtualRegister:
+    case OperandType::kVirtualRegister:
       return register_name() == other.register_name() && size() == other.size();
   }
 }
@@ -110,7 +110,7 @@ bool InstructionOperand::operator==(const InstructionOperand& other) const {
 InstructionOperand InstructionOperand::VirtualRegister(
     const std::string register_name, size_t size) {
   InstructionOperand result;
-  result.type_ = OperandType::KVirtualRegister;
+  result.type_ = OperandType::kVirtualRegister;
   result.register_name_ = std::move(register_name);
   result.size_ = size;
   return result;
@@ -233,6 +233,10 @@ std::string InstructionOperand::ToString() const {
       break;
     case OperandType::kMemory:
       buffer << ".from_memory(" << alias_group_id() << ")";
+      break;
+    case OperandType::kVirtualRegister:
+      buffer << ".from_virtual_register('" << register_name() << "', " << size()
+             << ")";
       break;
   }
   return buffer.str();

--- a/gematria/basic_block/basic_block.cc
+++ b/gematria/basic_block/basic_block.cc
@@ -39,6 +39,7 @@ std::ostream& operator<<(std::ostream& os, OperandType operand_type) {
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kFpImmediateValue);
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kAddress);
     GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::kMemory);
+    GEMATRIA_PRINT_ENUM_VALUE_TO_OS(os, OperandType::KVirtualRegister);
   }
   return os;
 }
@@ -101,7 +102,18 @@ bool InstructionOperand::operator==(const InstructionOperand& other) const {
       return address() == other.address();
     case OperandType::kMemory:
       return alias_group_id() == other.alias_group_id();
+    case OperandType::KVirtualRegister:
+      return register_name() == other.register_name() && size() == other.size();
   }
+}
+
+InstructionOperand InstructionOperand::VirtualRegister(
+    const std::string register_name, size_t size) {
+  InstructionOperand result;
+  result.type_ = OperandType::KVirtualRegister;
+  result.register_name_ = std::move(register_name);
+  result.size_ = size;
+  return result;
 }
 
 InstructionOperand InstructionOperand::Register(
@@ -188,6 +200,8 @@ void InstructionOperand::AddTokensToList(
       break;
     case OperandType::kMemory:
       tokens.emplace_back(kMemoryToken);
+      break;
+    default:
       break;
   }
 }

--- a/gematria/basic_block/basic_block.cc
+++ b/gematria/basic_block/basic_block.cc
@@ -202,7 +202,7 @@ void InstructionOperand::AddTokensToList(
       tokens.emplace_back(kMemoryToken);
       break;
     case OperandType::kVirtualRegister:
-      tokens.emplace_back(VREG_TOKEN(size()));
+      tokens.emplace_back(getVREG_TOKEN(size()));
       break;
   }
 }

--- a/gematria/basic_block/basic_block.cc
+++ b/gematria/basic_block/basic_block.cc
@@ -202,7 +202,7 @@ void InstructionOperand::AddTokensToList(
       tokens.emplace_back(kMemoryToken);
       break;
     case OperandType::kVirtualRegister:
-      tokens.emplace_back(std::string{kVirtualRegisterToken} + std::to_string(size()) + "_");
+      tokens.emplace_back(VREG_TOKEN(size()));
       break;
   }
 }

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -69,7 +69,8 @@ enum class OperandType {
   // also an operand of type kAddress.
   kMemory,
 
-  KVirtualRegister,
+  // The operand is a virtual register.
+  kVirtualRegister,
 };
 
 std::ostream& operator<<(std::ostream& os, OperandType operand_type);
@@ -142,7 +143,8 @@ class InstructionOperand {
   InstructionOperand& operator=(InstructionOperand&&) = default;
 
   // The operands must be created through one of the factory functions.
-  static InstructionOperand VirtualRegister(std::string register_name, size_t size);
+  static InstructionOperand VirtualRegister(std::string register_name,
+                                            size_t size);
   static InstructionOperand Register(std::string register_name);
   static InstructionOperand ImmediateValue(uint64_t immediate_value);
   static InstructionOperand FpImmediateValue(double fp_immediate_value);
@@ -178,7 +180,8 @@ class InstructionOperand {
   const size_t size() const { return size_; }
   // Returns the name of the register. Valid only when type() is kRegister.
   const std::string& register_name() const {
-    assert(type_ == OperandType::kRegister || type_ == OperandType::KVirtualRegister);
+    assert(type_ == OperandType::kRegister ||
+           type_ == OperandType::kVirtualRegister);
     return register_name_;
   }
 
@@ -212,8 +215,8 @@ class InstructionOperand {
 
  private:
   OperandType type_ = OperandType::kUnknown;
-  
-  size_t size_ ;
+
+  size_t size_;
   std::string register_name_;
   uint64_t immediate_value_ = 0;
   double fp_immediate_value_ = 0.0;

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -68,6 +68,8 @@ enum class OperandType {
   // The operand is a memory access. Instructions with this operand often have
   // also an operand of type kAddress.
   kMemory,
+
+  KVirtualRegister,
 };
 
 std::ostream& operator<<(std::ostream& os, OperandType operand_type);
@@ -140,6 +142,7 @@ class InstructionOperand {
   InstructionOperand& operator=(InstructionOperand&&) = default;
 
   // The operands must be created through one of the factory functions.
+  static InstructionOperand VirtualRegister(std::string register_name, size_t size);
   static InstructionOperand Register(std::string register_name);
   static InstructionOperand ImmediateValue(uint64_t immediate_value);
   static InstructionOperand FpImmediateValue(double fp_immediate_value);
@@ -172,9 +175,10 @@ class InstructionOperand {
   // kUnknown.
   OperandType type() const { return type_; }
 
+  const size_t size() const { return size_; }
   // Returns the name of the register. Valid only when type() is kRegister.
   const std::string& register_name() const {
-    assert(type_ == OperandType::kRegister);
+    assert(type_ == OperandType::kRegister || type_ == OperandType::KVirtualRegister);
     return register_name_;
   }
 
@@ -208,7 +212,8 @@ class InstructionOperand {
 
  private:
   OperandType type_ = OperandType::kUnknown;
-
+  
+  size_t size_ ;
   std::string register_name_;
   uint64_t immediate_value_ = 0;
   double fp_immediate_value_ = 0.0;

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -30,7 +30,7 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-
+#define VREG_TOKEN(SIZE) "_VREG" #SIZE "_"
 namespace gematria {
 
 // Tokens used for instruction canonicalization in Gematria. The values used

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -42,6 +42,7 @@ inline constexpr std::string_view kAddressToken = "_ADDRESS_";
 inline constexpr std::string_view kMemoryToken = "_MEMORY_";
 inline constexpr std::string_view kNoRegisterToken = "_NO_REGISTER_";
 inline constexpr std::string_view kDisplacementToken = "_DISPLACEMENT_";
+inline constexpr std::string_view kVirtualRegisterToken = "_VREG";
 
 // The type of an operand of an instruction.
 enum class OperandType {

--- a/gematria/basic_block/basic_block.h
+++ b/gematria/basic_block/basic_block.h
@@ -30,7 +30,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#define VREG_TOKEN(SIZE) "_VREG" #SIZE "_"
 namespace gematria {
 
 // Tokens used for instruction canonicalization in Gematria. The values used
@@ -43,6 +42,9 @@ inline constexpr std::string_view kMemoryToken = "_MEMORY_";
 inline constexpr std::string_view kNoRegisterToken = "_NO_REGISTER_";
 inline constexpr std::string_view kDisplacementToken = "_DISPLACEMENT_";
 inline constexpr std::string_view kVirtualRegisterToken = "_VREG";
+inline std::string getVREG_TOKEN(size_t size) {
+  return std::string(kVirtualRegisterToken) + std::to_string(size) + "_";
+} 
 
 // The type of an operand of an instruction.
 enum class OperandType {

--- a/gematria/basic_block/basic_block_protos.cc
+++ b/gematria/basic_block/basic_block_protos.cc
@@ -85,6 +85,14 @@ CanonicalizedOperandProto ProtoFromInstructionOperand(
     case OperandType::kMemory:
       proto.mutable_memory()->set_alias_group_id(operand.alias_group_id());
       break;
+    case OperandType::KVirtualRegister:
+      {
+        CanonicalizedOperandProto::VirtualRegister* virtual_register =
+            proto.mutable_virtual_register();
+        virtual_register->set_name(operand.register_name());
+        virtual_register->set_size(operand.size());
+        break;
+      }
     case OperandType::kUnknown:
       break;
   }

--- a/gematria/basic_block/basic_block_protos.cc
+++ b/gematria/basic_block/basic_block_protos.cc
@@ -63,6 +63,9 @@ InstructionOperand InstructionOperandFromProto(
     case CanonicalizedOperandProto::kMemory:
       return InstructionOperand::MemoryLocation(
           proto.memory().alias_group_id());
+    case CanonicalizedOperandProto::kVirtualRegister:
+      return InstructionOperand::VirtualRegister(
+          proto.virtual_register().name(), proto.virtual_register().size());
   }
 }
 
@@ -85,14 +88,13 @@ CanonicalizedOperandProto ProtoFromInstructionOperand(
     case OperandType::kMemory:
       proto.mutable_memory()->set_alias_group_id(operand.alias_group_id());
       break;
-    case OperandType::KVirtualRegister:
-      {
-        CanonicalizedOperandProto::VirtualRegister* virtual_register =
-            proto.mutable_virtual_register();
-        virtual_register->set_name(operand.register_name());
-        virtual_register->set_size(operand.size());
-        break;
-      }
+    case OperandType::kVirtualRegister: {
+      CanonicalizedOperandProto::VirtualRegister* virtual_register =
+          proto.mutable_virtual_register();
+      virtual_register->set_name(operand.register_name());
+      virtual_register->set_size(operand.size());
+      break;
+    }
     case OperandType::kUnknown:
       break;
   }

--- a/gematria/basic_block/basic_block_protos_test.cc
+++ b/gematria/basic_block/basic_block_protos_test.cc
@@ -234,5 +234,29 @@ TEST(BasicBlockFromProtoTest, SomeInstructions) {
                /* implicit_output_operands = */ {})}));
 }
 
+TEST(BasicBlockFromProtoTest, VRegInstructions) {
+  const BasicBlockProto proto = ParseTextProto(R"pb(
+    canonicalized_instructions {
+      mnemonic: "CMP64RI32"
+      llvm_mnemonic: "CMP64ri32"
+      input_operands { virtual_register { name: "%60" size: 64 } }
+      input_operands { immediate_value: 0 }
+      implicit_output_operands { register_name: "EFLAGS" }
+    }
+  )pb");
+  const BasicBlock block = BasicBlockFromProto(proto);
+  EXPECT_EQ(block,
+            BasicBlock({Instruction(
+                /* mnemonic = */ "CMP64RI32", /* llvm_mnemonic = */ "CMP64ri32",
+                /* prefixes = */ {},
+                /* input_operands = */
+                {InstructionOperand::VirtualRegister("%60", 64),
+                 InstructionOperand::ImmediateValue(0)},
+                /* implicit_input_operands = */ {},
+                /* output_operands = */ {},
+                /* implicit_output_operands = */
+                {InstructionOperand::Register("EFLAGS")})}));
+}
+
 }  // namespace
 }  // namespace gematria

--- a/gematria/datasets/bhive_importer.cc
+++ b/gematria/datasets/bhive_importer.cc
@@ -42,7 +42,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
-#define DEBUG
+
 
 #ifdef DEBUG
 #define LOG(X) \

--- a/gematria/datasets/python/BUILD
+++ b/gematria/datasets/python/BUILD
@@ -64,3 +64,16 @@ gematria_py_binary(
         "//gematria/utils/python:pybind11_abseil_status",
     ],
 )
+
+gematria_py_binary(
+    name = "gen_tokens",
+    srcs = ["gen_tokens.py"],
+    deps = [
+        "//gematria/basic_block/python:basic_block_protos",
+        "//gematria/basic_block/python:basic_block",
+        "//gematria/io/python:tfrecord",
+        "//gematria/proto:basic_block_py_pb2",
+        "//gematria/proto:canonicalized_instruction_py_pb2",
+        "//gematria/proto:throughput_py_pb2",
+    ],
+)

--- a/gematria/datasets/python/gen_tokens.py
+++ b/gematria/datasets/python/gen_tokens.py
@@ -1,0 +1,64 @@
+from gematria.basic_block.python import basic_block
+from gematria.basic_block.python import basic_block_protos
+from gematria.proto import basic_block_pb2
+from gematria.proto import throughput_pb2
+from gematria.proto import canonicalized_instruction_pb2
+from gematria.io.python import tfrecord
+
+from collections.abc import Sequence
+
+from absl import app
+from absl import flags
+from absl import logging
+
+_CanonicalizedInstructionProto = (
+    canonicalized_instruction_pb2.CanonicalizedInstructionProto
+)
+
+r"""Generates tokens from a Gematria data set.
+
+
+Usage:
+  gen_tokens \
+      --gematria_input_tfrecord=/tmp/bhive/skl.tfrecord \
+      --gematria_output_tokens=/tmp/bhive/skl_tokens.txt \
+
+"""
+
+_INPUT_TFRECORD_FILE = flags.DEFINE_string(
+    'gematria_input_tfrecord',
+    None,
+    'The name of the TFRecord file to read the tokens from.',
+    required=True,
+)
+
+_OUTPUT_TOKENS_FILE = flags.DEFINE_string(
+    'gematria_output_tokens',
+    None,
+    'The name of the file to write the tokens to.',
+    required=True,
+)
+
+def main(argv: Sequence[str]) -> None:
+  if len(argv) > 1:
+    raise app.UsageError('Too many command-line arguments.')
+  output_blocks = list(
+    tfrecord.read_protos((_INPUT_TFRECORD_FILE.value,), throughput_pb2.BasicBlockWithThroughputProto)
+  )
+  token_set = set()
+  for block in output_blocks:
+    for instruction in block.basic_block.canonicalized_instructions:
+     ginstruction = basic_block_protos.instruction_from_proto(instruction)
+     for token in ginstruction.as_token_list():
+       if not token.startswith('%'):
+        token_set.add(token)
+  print(token_set)
+  with open(_OUTPUT_TOKENS_FILE.value, 'w') as f:
+    for token in token_set:
+      f.write(token)
+      f.write('\n')
+      
+  
+
+if __name__ == '__main__':
+  app.run(main)

--- a/gematria/datasets/python/import_from_mir.py
+++ b/gematria/datasets/python/import_from_mir.py
@@ -111,7 +111,6 @@ from gematria.llvm.python import llvm_architecture_support
 from pybind11_abseil import status
 import tensorflow as tf
 
-machine_hex_set = set()
 
 def main(argv: Sequence[str]) -> None:
   if len(argv) > 1:
@@ -177,11 +176,6 @@ def main(argv: Sequence[str]) -> None:
                                 if float(through_put) == -1:
                                     num_skipped_blocks += 1
                                     continue
-                                # skip blocks with duplicate machine code
-                                if hex in machine_hex_set:
-                                    num_skipped_blocks += 1
-                                    continue
-                                machine_hex_set.add(hex)
                                 block_proto = importer.ParseMIRCsvLine(
                                     source_name=_SOURCE_NAME.value,
                                     line=line.strip(),

--- a/gematria/datasets/python/import_from_mir.py
+++ b/gematria/datasets/python/import_from_mir.py
@@ -42,6 +42,13 @@ _INPUT_DIR = flags.DEFINE_string(
     'The name of directory containing all raw MIR files with performance throughput',
     required=True,
 )
+
+_INPUT_DIR2 = flags.DEFINE_string(
+    'gematria_input_dir2',
+    None,
+    'The name of directory containing all raw MIR files with performance throughput',
+)
+
 _OUTPUT_TFRECORD_FILE = flags.DEFINE_string(
     'gematria_output_tfrecord',
     None,
@@ -132,58 +139,62 @@ def main(argv: Sequence[str]) -> None:
     num_input_files = 0
     num_skipped_blocks = 0
     num_skipped_files = 0
-    for filename in os.listdir(_INPUT_DIR.value):
-        if filename.endswith(".mir"):
-            if num_input_files % 1000 == 0:
-                logging.info(
-                    'Processed %d files, skipped %d.',
-                    num_input_files,
-                    num_skipped_files,
-                )
-            mir_file = os.path.join(_INPUT_DIR.value, filename)
-            print("mir file is " + mir_file)
-            perf_file = os.path.join(_INPUT_DIR.value, filename.replace(".mir", ".perf"))
-            try:
-                # load the MIR file
-                module = importer.LoadMIRModule(mir_file)
-                num_input_files += 1
-                logging.info('Procssing %s file', mir_file)
-                # iterate over each line in the corresponding .perf file
-                with tf.io.gfile.GFile(perf_file, 'r') as bhive_csv_file:
-                    for line in bhive_csv_file:
-                        if num_input_blocks % 1000 == 0:
-                            logging.info(
-                                'Processed %d blocks, skipped %d.',
-                                num_input_blocks,
-                                num_skipped_blocks,
-                            )
-                        num_input_blocks += 1
-                        try:
-                            hex = line.split(",")[_MACHINE_HEX_COLUMN_INDEX.value]
-                            BB_name = line.split(",")[_MACHINE_BASIC_BLOCK_NAME_COLUMN_INDEX.value]
-                            through_put = line.split(",")[_THROUGHPUT_COLUMN_INDEX.value]
-                            # skip blocks with throughput -1
-                            if float(through_put) == -1:
+    input_dirs = [_INPUT_DIR.value]
+    if _INPUT_DIR2.value:
+        input_dirs.append(_INPUT_DIR2.value)
+    for input_dir in input_dirs:
+        for filename in os.listdir(input_dir):
+            if filename.endswith(".mir"):
+                if num_input_files % 1000 == 0:
+                    logging.info(
+                        'Processed %d files, skipped %d.',
+                        num_input_files,
+                        num_skipped_files,
+                    )
+                mir_file = os.path.join(_INPUT_DIR.value, filename)
+                print("mir file is " + mir_file)
+                perf_file = os.path.join(_INPUT_DIR.value, filename.replace(".mir", ".perf"))
+                try:
+                    # load the MIR file
+                    module = importer.LoadMIRModule(mir_file)
+                    num_input_files += 1
+                    logging.info('Procssing %s file', mir_file)
+                    # iterate over each line in the corresponding .perf file
+                    with tf.io.gfile.GFile(perf_file, 'r') as bhive_csv_file:
+                        for line in bhive_csv_file:
+                            if num_input_blocks % 1000 == 0:
+                                logging.info(
+                                    'Processed %d blocks, skipped %d.',
+                                    num_input_blocks,
+                                    num_skipped_blocks,
+                                )
+                            num_input_blocks += 1
+                            try:
+                                hex = line.split(",")[_MACHINE_HEX_COLUMN_INDEX.value]
+                                BB_name = line.split(",")[_MACHINE_BASIC_BLOCK_NAME_COLUMN_INDEX.value]
+                                through_put = line.split(",")[_THROUGHPUT_COLUMN_INDEX.value]
+                                # skip blocks with throughput -1
+                                if float(through_put) == -1:
+                                    num_skipped_blocks += 1
+                                    continue
+                                # skip blocks with duplicate machine code
+                                if hex in machine_hex_set:
+                                    num_skipped_blocks += 1
+                                    continue
+                                machine_hex_set.add(hex)
+                                block_proto = importer.ParseMIRCsvLine(
+                                    source_name=_SOURCE_NAME.value,
+                                    line=line.strip(),
+                                    BB_name_index = _MACHINE_BASIC_BLOCK_NAME_COLUMN_INDEX.value,
+                                    throughput_column_index = _THROUGHPUT_COLUMN_INDEX.value,
+                                    throughput_scaling=_THROUGHPUT_SCALING.value,
+                                )
+                                writer.write(block_proto.SerializeToString())
+                            except:
                                 num_skipped_blocks += 1
-                                continue
-                            # skip blocks with duplicate machine code
-                            if hex in machine_hex_set:
-                                num_skipped_blocks += 1
-                                continue
-                            machine_hex_set.add(hex)
-                            block_proto = importer.ParseMIRCsvLine(
-                                source_name=_SOURCE_NAME.value,
-                                line=line.strip(),
-                                BB_name_index = _MACHINE_BASIC_BLOCK_NAME_COLUMN_INDEX.value,
-                                throughput_column_index = _THROUGHPUT_COLUMN_INDEX.value,
-                                throughput_scaling=_THROUGHPUT_SCALING.value,
-                            )
-                            writer.write(block_proto.SerializeToString())
-                        except:
-                            num_skipped_blocks += 1
-            except:
-                logging.exception('Could not load file "%s"', mir_file)
-                num_skipped_files += 1
+                except:
+                    logging.exception('Could not load file "%s"', mir_file)
+                    num_skipped_files += 1
     logging.info(
         'Processed %d files, skipped %d.',
         num_input_files,

--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -29,8 +29,6 @@
 #include "gematria/basic_block/basic_block.h"
 #include "gematria/model/oov_token_behavior.h"
 
-#define DEBUG
-
 #ifdef DEBUG
 #define LOG(X) \
   std::cerr << X << "\n"
@@ -299,32 +297,33 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       const AddressTuple& address_tuple = operand.address();
       if (!address_tuple.base_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
-        LOG("base register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
         std::string vreg_token = getVREG_TOKEN(64);
-        if (!AddDependencyOnRegister(address_node, address_tuple.base_register,
-                                     vreg_token,
-                                     EdgeType::kAddressBaseRegister)) {
+        bool result = AddDependencyOnRegister(address_node, address_tuple.base_register,
+                                     is_virtual_reg ? vreg_token : address_tuple.base_register,
+                                     EdgeType::kAddressBaseRegister);
+        if (result == false) {
           return false;
         }
       }
       if (!address_tuple.index_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
-        LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
         std::string vreg_token = getVREG_TOKEN(64);
-        if (!AddDependencyOnRegister(address_node, address_tuple.index_register,
-                                     vreg_token,
-                                     EdgeType::kAddressIndexRegister)) {
+        bool result = AddDependencyOnRegister(address_node,
+                                     address_tuple.index_register,
+                                     is_virtual_reg ? vreg_token : address_tuple.index_register,
+                                     EdgeType::kAddressIndexRegister);
+        if (result == false) {
           return false;
         }
       }
       if (!address_tuple.segment_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
-        LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
         std::string vreg_token = getVREG_TOKEN(64);
-        if (!AddDependencyOnRegister(address_node,
+        bool result = AddDependencyOnRegister(address_node,
                                      address_tuple.segment_register,
-                                     vreg_token,
-                                     EdgeType::kAddressSegmentRegister)) {
+                                     is_virtual_reg ? vreg_token : address_tuple.segment_register,
+                                     EdgeType::kAddressSegmentRegister);
+        if (result == false) {
           return false;
         }
       }

--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -277,7 +277,7 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       }
     } break;
     case OperandType::kVirtualRegister: {
-      std::string vreg_name = VREG_TOKEN(operand.size());
+      std::string vreg_name = getVREG_TOKEN(operand.size());
       if (!AddDependencyOnRegister(instruction_node, operand.register_name(),
                                    vreg_name, EdgeType::kInputOperands)) {
         return false;
@@ -300,7 +300,7 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       if (!address_tuple.base_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
         LOG("base register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
-        std::string vreg_token = VREG_TOKEN(64);
+        std::string vreg_token = getVREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node, address_tuple.base_register,
                                      vreg_token,
                                      EdgeType::kAddressBaseRegister)) {
@@ -310,7 +310,7 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       if (!address_tuple.index_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
         LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
-        std::string vreg_token = VREG_TOKEN(64);
+        std::string vreg_token = getVREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node, address_tuple.index_register,
                                      vreg_token,
                                      EdgeType::kAddressIndexRegister)) {
@@ -320,7 +320,7 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       if (!address_tuple.segment_register.empty()) {
         bool is_virtual_reg = address_tuple.base_register[0] == '%';
         LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
-        std::string vreg_token = VREG_TOKEN(64);
+        std::string vreg_token = getVREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node,
                                      address_tuple.segment_register,
                                      vreg_token,
@@ -365,7 +365,7 @@ bool BasicBlockGraphBuilder::AddOutputOperand(
       register_nodes_[operand.register_name()] = register_node;
     } break;
     case OperandType::kVirtualRegister: {
-      std::string vreg_name = VREG_TOKEN(operand.size());
+      std::string vreg_name = getVREG_TOKEN(operand.size());
       const NodeIndex register_node =
           AddNode(NodeType::kRegister, vreg_name);
       if (register_node == kInvalidNode) return false;

--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -29,6 +29,15 @@
 #include "gematria/basic_block/basic_block.h"
 #include "gematria/model/oov_token_behavior.h"
 
+#define DEBUG
+
+#ifdef DEBUG
+#define LOG(X) \
+  std::cerr << X << "\n"
+#else
+#define LOG(X)
+#endif
+
 namespace gematria {
 namespace {
 
@@ -268,7 +277,7 @@ bool BasicBlockGraphBuilder::AddInputOperand(
       }
     } break;
     case OperandType::kVirtualRegister: {
-      std::string vreg_name = "VREG" + std::to_string(operand.size());
+      std::string vreg_name = VREG_TOKEN(operand.size());
       if (!AddDependencyOnRegister(instruction_node, operand.register_name(),
                                    vreg_name, EdgeType::kInputOperands)) {
         return false;
@@ -289,23 +298,32 @@ bool BasicBlockGraphBuilder::AddInputOperand(
           AddNode(NodeType::kAddressOperand, address_token_);
       const AddressTuple& address_tuple = operand.address();
       if (!address_tuple.base_register.empty()) {
+        bool is_virtual_reg = address_tuple.base_register[0] == '%';
+        LOG("base register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
+        std::string vreg_token = VREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node, address_tuple.base_register,
-                                     address_tuple.base_register,
+                                     vreg_token,
                                      EdgeType::kAddressBaseRegister)) {
           return false;
         }
       }
       if (!address_tuple.index_register.empty()) {
+        bool is_virtual_reg = address_tuple.base_register[0] == '%';
+        LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
+        std::string vreg_token = VREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node, address_tuple.index_register,
-                                     address_tuple.index_register,
+                                     vreg_token,
                                      EdgeType::kAddressIndexRegister)) {
           return false;
         }
       }
       if (!address_tuple.segment_register.empty()) {
+        bool is_virtual_reg = address_tuple.base_register[0] == '%';
+        LOG("index register: " << address_tuple.base_register << " is virtual: " << is_virtual_reg);
+        std::string vreg_token = VREG_TOKEN(64);
         if (!AddDependencyOnRegister(address_node,
                                      address_tuple.segment_register,
-                                     address_tuple.segment_register,
+                                     vreg_token,
                                      EdgeType::kAddressSegmentRegister)) {
           return false;
         }
@@ -347,7 +365,7 @@ bool BasicBlockGraphBuilder::AddOutputOperand(
       register_nodes_[operand.register_name()] = register_node;
     } break;
     case OperandType::kVirtualRegister: {
-      std::string vreg_name = "VREG" + std::to_string(operand.size());
+      std::string vreg_name = VREG_TOKEN(operand.size());
       const NodeIndex register_node =
           AddNode(NodeType::kRegister, vreg_name);
       if (register_node == kInvalidNode) return false;

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -352,6 +352,7 @@ class BasicBlockGraphBuilder {
   // a register. Adds the register node if it doesn't exist in the graph.
   bool AddDependencyOnRegister(NodeIndex dependent_node,
                                const std::string& register_name,
+                               const std::string& register_token, 
                                EdgeType edge_type);
 
   // Adds a new node to the batch; the feature of the node is given directly by

--- a/gematria/io/python/utils.py
+++ b/gematria/io/python/utils.py
@@ -162,6 +162,22 @@ def _scale_values(
   for i in range(len(values)):
     values[i] *= scaling_factor
 
+def drop_blocks_with_empty_instructions(
+    block: throughput_pb2.BasicBlockWithThroughputProto
+) -> Optional[throughput_pb2.BasicBlockWithThroughputProto]:
+  """Removes basic blocks that do not have any instructions.
+
+  Returns `block` unchanged if it has at least one instruction.
+
+  Args:
+    block: The basic block proto to inspect.
+
+  Returns:
+    None when `block` has no instructions; otherwise, returns `block`.
+  """
+  if block.basic_block.canonicalized_instructions:
+    return block
+  return None
 
 def drop_blocks_with_no_throughputs(
     use_prefixes: bool, block: throughput_pb2.BasicBlockWithThroughputProto

--- a/gematria/llvm/canonicalizer.cc
+++ b/gematria/llvm/canonicalizer.cc
@@ -36,7 +36,6 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include <sstream>
 
-#define DEBUG
 
 #ifdef DEBUG
 #define LOG(X) \

--- a/gematria/llvm/canonicalizer.h
+++ b/gematria/llvm/canonicalizer.h
@@ -68,7 +68,7 @@ class Canonicalizer {
   // the operand is an "undefined" operand.
   // This method must not be called when `operand.isReg()` is false.
   std::string GetRegisterNameOrEmpty(const llvm::MCOperand& operand) const;
-  std::string GetRegisterNameOrEmpty(const llvm::MachineOperand& operand) const;
+  bool GetRegisterNameOrEmpty(const llvm::MachineOperand& operand, std::string& name, size_t& size) const;
 
   const llvm::TargetMachine& target_machine_;
 };

--- a/gematria/model/python/main_function.py
+++ b/gematria/model/python/main_function.py
@@ -715,6 +715,11 @@ def _make_basic_block_reader_from_command_line_flags(
     proto_filters.append(
         functools.partial(utils.aggregate_throughputs, throughput_selection)
     )
+    proto_filters.append(
+        functools.partial(
+            utils.drop_blocks_with_empty_instructions,
+        )
+    )
     if _INPUT_FILE_SCALING.value != 1.0:
       proto_filters.append(
           functools.partial(utils.scale_throughputs, _INPUT_FILE_SCALING.value)

--- a/gematria/proto/canonicalized_instruction.proto
+++ b/gematria/proto/canonicalized_instruction.proto
@@ -87,6 +87,13 @@ message CanonicalizedOperandProto {
     int32 alias_group_id = 1;
   }
 
+  message VirtualRegister {
+    // The name of the virtual register.
+    string name = 1;
+    // The size of the virtual register in bits.
+    int32 size = 2;
+  }
+
   // The operand must be exactly one of the following:
   //   - a register,
   //   - an integer immediate value,
@@ -113,5 +120,7 @@ message CanonicalizedOperandProto {
     AddressTuple address = 4;
     // The information about the memory location accessed by the instruction.
     MemoryLocation memory = 5;
+    // The information about the virtual register.
+    VirtualRegister virtual_register = 6;
   }
 }


### PR DESCRIPTION
New proto looks like
```
  canonicalized_instructions {
    mnemonic: "CMOV64RR"
    llvm_mnemonic: "CMOV64rr"
    output_operands {
      virtual_register {
        name: "%255"
        size: 64
      }
    }
    input_operands {
      virtual_register {
        name: "%254"
        size: 64
      }
    }
    input_operands {
      virtual_register {
        name: "%159"
        size: 64
      }
    }
    input_operands {
      immediate_value: 4
    }
    implicit_input_operands {
      register_name: "EFLAGS"
    }
  }
```

Milestone 1 Done! Training pipeline works successfully in MIR level